### PR TITLE
JsonClassConverter supports lowercase

### DIFF
--- a/addons/JsonClassConverter/JsonClassConverter.gd
+++ b/addons/JsonClassConverter/JsonClassConverter.gd
@@ -140,7 +140,7 @@ static func json_to_class(castClass: GDScript, json: Dictionary) -> Object:
 							if enum_str.contains(":"):
 								var enum_keys: Array = enum_str.split(":")
 								for i: int in enum_keys.size():
-									if enum_keys[i] == value:
+									if enum_keys[i].to_lower() == value.to_lower():
 										enum_value = int(enum_keys[i + 1])
 						_class.set(property.name, enum_value)
 					else:


### PR DESCRIPTION
I had this issue using this addon when trying to parse from `JSON `to `Class` this one containing a Enum inside. When we're getting the keys from Enum first letter is in capital so we're forced to change our `JSON` in order to match it. Forcing both to lowercase would solve the problem and I think matching the value regardless if we have any letter in capital or not is better for `Enum` in general