### PR TITLE
Support dictionary values that are not strings when serialized

### DIFF
--- a/addons/JsonClassConverter/JsonClassConverter.gd
+++ b/addons/JsonClassConverter/JsonClassConverter.gd
@@ -205,6 +205,8 @@ static func convert_json_to_dictionary(propert_value: Dictionary, json_dictionar
 			value_obj = json_to_class(value_script, json_value)
 		elif typeof(json_value) == TYPE_ARRAY:
 			value_obj = convert_json_to_array(json_value)
+		elif typeof(dic_value) == TYPE_BOOL or typeof(dic_value) == TYPE_INT or typeof(dic_value) == TYPE_FLOAT:
+			value_obj = dic_value
 		else:
 			value_obj = str_to_var(json_value)
 			if !value_obj: # if null revert to json key

--- a/addons/JsonClassConverter/JsonClassConverter.gd
+++ b/addons/JsonClassConverter/JsonClassConverter.gd
@@ -205,8 +205,8 @@ static func convert_json_to_dictionary(propert_value: Dictionary, json_dictionar
 			value_obj = json_to_class(value_script, json_value)
 		elif typeof(json_value) == TYPE_ARRAY:
 			value_obj = convert_json_to_array(json_value)
-		elif typeof(dic_value) == TYPE_BOOL or typeof(dic_value) == TYPE_INT or typeof(dic_value) == TYPE_FLOAT:
-			value_obj = dic_value
+		elif typeof(json_value) == TYPE_BOOL or typeof(json_value) == TYPE_INT or typeof(json_value) == TYPE_FLOAT:
+			value_obj = json_value
 		else:
 			value_obj = str_to_var(json_value)
 			if !value_obj: # if null revert to json key


### PR DESCRIPTION
Found an edge case where some non-string json values were treated as strings, causing a parse error. When the class uses a typed dictionary, and a value of that typed dictionary is not json serialized as a string, dictionary, or array, `str_to_var` is called on the value. This doesn't account for booleans and numeric types.

## Reproduction

The following resource class:

```gdscript
class_name TestResource extends Resource

@export var typed_dict : Dictionary[String, Variant]
```

And the following scene script:
```gdscript
extends Node

var json := {
    "typed_dict": {
        "string_val": "foo",
        "bool_val": true,
        "int_val": 5,
        "float_val": 5.2
    }
}

func _ready() -> void:
    var result = JsonClassConverter.json_to_class(TestResource, json)
```
produces errors when handling the bool, int, and float.

## Fix

This fix adds an extra check for these three types before moving to the `else` statement that causes the issue.