### PR TITLE
JsonClassConverter supports Dictonary to Class without castClass

### DIFF
--- a/addons/JsonClassConverter/JsonClassConverter.gd
+++ b/addons/JsonClassConverter/JsonClassConverter.gd
@@ -117,7 +117,7 @@ static func json_to_class_unknown(json: Dictionary) -> Object:
 		printerr("The json doesn't contains the 'script_inheritance' (class's name)")
 		return null
 	
-	var script_type: Object = get_gdscript(json["script_inheritance"])
+	var script_type: Object = _get_gdscript(json["script_inheritance"])
 	if script_type == null:
 		print("The class given ", json["script_inheritance"], " couldn't be found in the global scope")
 		return null


### PR DESCRIPTION
first of all, awesome addon.

so... I had this problem where I have 3 classes where I save stuff, but at some point that data have to be saved in a file, so I'm using this addon to convert its properties into a parsed JSON where I can more easily manipulate its contents

BUT, the addon only supports "class to json" specifying the source class, but I don't want to check if the saved JSON have a key or other to specify the source class, so using the functions that the addon already provides, I made a function that based on a json, using `script_inheritance` key, it get and load the corresponding class and parse those arguments to `class_to_json` function to complete the cycle 

I think working around this a bit more, there's a possibility to add another key (like `script_base`), so the JSON generated by the addon can be loaded without having to specify the class in future loads

hope this helps 💃 