### PR TITLE
🔒 [security fix] Insecure Deserialization via str_to_var

### DIFF
--- a/addons/ForgeJSONGD/ForgeJSONGD.gd
+++ b/addons/ForgeJSONGD/ForgeJSONGD.gd
@@ -158,7 +158,7 @@ static func json_to_class(script_or_instace: Variant, json: Dictionary) -> Objec
 	for key: String in json.keys():
 		var value: Variant = json.get(key)
 		# Special handling for Vector types (stored as strings in JSON)
-		if type_string(typeof(value)) == "String" and value.begins_with("Vector"):
+		if type_string(typeof(value)) == "String" and _is_safe_type(value):
 			value = str_to_var(value)
 			
 		# Find the matching property in the target class


### PR DESCRIPTION
This PR addresses a security vulnerability where `str_to_var` was used on untrusted JSON input, which could lead to arbitrary object instantiation and code execution. 

I've introduced a whitelist-based validation function `_is_safe_type` that only allows `str_to_var` to be called on safe built-in Godot types (Vector2, Vector3, Rect2, etc.) and explicitly blocks dangerous types like `Object`, `Callable`, and `Signal`.

🎯 **What:** The vulnerability fixed is insecure deserialization via `str_to_var`.
⚠️ **Risk:** Potential Remote Code Execution (RCE) if an attacker provides a malicious JSON containing stringified Godot objects.
🛡️ **Solution:** Implemented a validation layer that ensures only safe, non-object built-in types are processed by `str_to_var`.

---
*PR created automatically by Jules for task [14142303265964273260](https://jules.google.com/task/14142303265964273260) started by @EiTaNBaRiBoA*